### PR TITLE
Add documentation, CI, and model skeletons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: setup train-teacher train-student eval user-demo
+
+setup:
+	python3 -m venv .venv || true
+	. .venv/bin/activate && pip install -U pip && pip install -r requirements.txt
+
+train-teacher:
+	python -m src.train.train_teacher --config configs/train_teacher.yaml
+
+train-student:
+	python -m src.train.train_student --config configs/train_student.yaml
+
+eval:
+	python -m src.eval.evaluate --config configs/eval.yaml
+
+user-demo:
+	bash scripts/user_run_local.sh --input sample.csv

--- a/README.md
+++ b/README.md
@@ -4,10 +4,23 @@ Scaffold for an e-nose ML/DL pipeline combining docking priors with low-cost
 sensor signals. This repository provides placeholders for data processing,
 model training, knowledge distillation, and user-side inference.
 
+## Quickstart
+### Developers (HPC)
+1. Edit YAML configs under `configs/`.
+2. Submit SLURM jobs:
+   ```bash
+   sbatch hpc/train_teacher.sbatch
+   sbatch hpc/train_student.sbatch
+   ```
+
+### Users (local CPU)
+Run the single helper script which creates a venv and launches the demo:
+```bash
+bash scripts/user_run_local.sh --input sample.csv
+```
 
 ## Config-first workflow
 All paths and hyperparameters are stored in YAML files under `configs/`.
 Developers modify these YAMLs and launch training via SLURM scripts in `hpc/`.
 End users run a single script (`scripts/user_run_local.sh`) which sets up a
 lightweight environment and calls the demo using `configs/user_infer.yaml`.
-

--- a/configs/project.yaml
+++ b/configs/project.yaml
@@ -1,7 +1,4 @@
-# Global project metadata
-name: obp-kd-enose
-sensors:
-  - SGP30
-  - CCS811
-  - BME280
-class_names: []  # fill with target VOC classes
+project_name: obp-kd-enose
+classes: [none, ipa, acetone, ethanol, toluene, acetic_acid]
+sensors: [sgp30_tvoc_ppb, ccs811_tvoc_ppb, bme280_temp_C, bme280_rh_pct]
+artifact_dir: artifacts

--- a/configs/train_teacher.yaml
+++ b/configs/train_teacher.yaml
@@ -1,32 +1,17 @@
-# Example training configuration for teacher model
-# All paths and hyperparameters are defined here.
-
-paths:
-  train_data: data/processed/train.parquet
-  val_data: data/processed/val.parquet
-  prior: data/priors/prior.json
-  output_dir: runs/teacher
-
-classes:
-  - ethanol
-  - methane
-
+seed: 1337
+data_config: configs/data.yaml
+prior_path: data/priors/prior.json
 model:
-  type: teacher
-  backbone: tcn      # or cnn
-  channels: 32
-  prior_dim: 7       # matches features in prior.json
-
-optimizer:
-  name: adam
-  lr: 0.001
-
-training:
-  epochs: 20
+  encoder: cnn1d
+  hidden: 64
+  prior_dim: 56
+train:
   batch_size: 64
-  seed: 42
-  num_workers: 4
-
-# Knowledge distillation is disabled for teacher training
-kd:
-  enabled: false
+  max_epochs: 40
+  lr: 3e-4
+  weight_decay: 1e-4
+loss:
+  ce_weight: 1.0
+  mse_weight: 0.3
+  align_weight: 0.1
+device: cuda

--- a/docs/PRIOR_SCHEMA.md
+++ b/docs/PRIOR_SCHEMA.md
@@ -1,3 +1,18 @@
 # Prior Schema
 
-Document the fields extracted from GNINA outputs. Placeholder for now.
+The docking prior embeds each VOC class into a fixed-length vector.
+
+## Fields
+- `class` *(string)*: VOC class label.
+- `embedding` *(list[float])*: length `D` feature vector.
+
+## Dimensions
+For this project `D = 56` features per class.
+
+## Example
+```json
+{
+  "acetone": [0.1, 0.2, 0.3],
+  "ethanol": [0.0, 0.1, 0.4]
+}
+```

--- a/docs/USAGE_HPC_vs_USER.md
+++ b/docs/USAGE_HPC_vs_USER.md
@@ -2,12 +2,14 @@
 
 ## Developers (HPC)
 - Edit YAML configs under `configs/` to set paths and hyperparameters.
-- Submit SLURM jobs with the helper scripts in `hpc/` (e.g. `sbatch hpc/train_teacher.sbatch`).
-- Training code reads all settings from the provided YAML files.
+- Submit SLURM jobs:
+  ```bash
+  sbatch hpc/train_teacher.sbatch
+  sbatch hpc/train_student.sbatch
+  ```
 
 ## Users (no HPC)
-- Run `scripts/user_run_local.sh`.
-- The script creates a virtual environment, installs `requirements_user.txt`,
-  downloads a release bundle containing a student ONNX model and
-  `configs/user_infer.yaml`, and executes the demo:
-  `python -m src.infer.user_demo --config configs/user_infer.yaml`.
+Run the demo on a local CPU machine:
+```bash
+bash scripts/user_run_local.sh --input sample.csv
+```

--- a/hpc/train_teacher.sbatch
+++ b/hpc/train_teacher.sbatch
@@ -1,5 +1,13 @@
-#!/bin/bash
-#SBATCH --job-name=train_teacher
-
-source env_activate.sh
-python src/train/train_teacher.py --config configs/train_teacher.yaml
+#!/usr/bin/env bash
+#SBATCH -p gpu1
+#SBATCH --gres=gpu:1
+#SBATCH -c 8
+#SBATCH --mem=24G
+#SBATCH -t 24:00:00
+#SBATCH -J enose_teacher
+#SBATCH -o logs/teacher_%j.out
+#SBATCH -e logs/teacher_%j.err
+set -e
+mkdir -p logs
+source hpc/env_activate.sh
+python -m src.train.train_teacher --config configs/train_teacher.yaml

--- a/scripts/user_run_local.sh
+++ b/scripts/user_run_local.sh
@@ -1,20 +1,7 @@
 #!/usr/bin/env bash
-# One-stop script for end users to run inference locally.
 set -e
-
-VENV=.venv
-if [ ! -d "$VENV" ]; then
-  python3 -m venv "$VENV"
-fi
-source "$VENV/bin/activate"
-
-pip install --quiet -r requirements_user.txt
-
-# Placeholder for downloading release bundle. In practice replace URL.
-BUNDLE_URL=${BUNDLE_URL:-https://example.com/release.tar.gz}
-RELEASE_DIR=release
-mkdir -p "$RELEASE_DIR"
-# curl -L "$BUNDLE_URL" | tar -xz -C "$RELEASE_DIR"  # commented placeholder
-
-python -m src.infer.user_demo --config configs/user_infer.yaml
-
+python3 -m venv .venv || true
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements_user.txt
+python -m src.infer.user_demo --config configs/user_infer.yaml "$@"

--- a/src/models/backbones.py
+++ b/src/models/backbones.py
@@ -10,14 +10,17 @@ class SimpleCNN(nn.Module):
 
     def __init__(self, in_channels: int = 1, out_dim: int = 8) -> None:
         super().__init__()
+        # TODO: replace with a proper CNN encoder for time-series data.
         self.net = nn.Sequential(
-            nn.Conv1d(in_channels, 8, kernel_size=3, padding=1),
+            nn.Conv1d(in_channels, out_dim, kernel_size=3, padding=1),
             nn.ReLU(),
             nn.AdaptiveAvgPool1d(1),
         )
-        self.out_dim = 8
+        self.out_dim = out_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode ``x`` of shape ``(B, C, L)`` into ``(B, out_dim)``."""
+        # TODO: extend with deeper network and normalisation layers.
         x = self.net(x)
         return x.view(x.size(0), -1)
 
@@ -27,11 +30,13 @@ class SimpleTCN(nn.Module):
 
     def __init__(self, in_channels: int = 1, out_dim: int = 8) -> None:
         super().__init__()
+        # TODO: implement real TCN with dilated convolutions.
         self.conv = nn.Conv1d(in_channels, out_dim, kernel_size=3, padding=1)
         self.pool = nn.AdaptiveAvgPool1d(1)
         self.out_dim = out_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode ``x`` of shape ``(B, C, L)`` into ``(B, out_dim)``."""
         x = torch.relu(self.conv(x))
         x = self.pool(x)
         return x.view(x.size(0), -1)

--- a/src/models/student.py
+++ b/src/models/student.py
@@ -12,6 +12,7 @@ class StudentModel(nn.Module):
 
     def __init__(self, num_classes: int = 3, hidden_dim: int = 32) -> None:
         super().__init__()
+        # TODO: swap SimpleCNN with a compact architecture suitable for MCUs.
         self.backbone = SimpleCNN(in_channels=1, out_dim=hidden_dim)
         self.classifier = nn.Linear(self.backbone.out_dim, num_classes)
         self.regressor = nn.Linear(self.backbone.out_dim, 1)
@@ -19,8 +20,17 @@ class StudentModel(nn.Module):
     def forward(
         self, x: torch.Tensor, *, return_tvoc: bool = False
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """Compute logits (and optionally a TVOC estimate)."""
+        """Compute logits (and optionally a TVOC estimate).
 
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input time series of shape ``(B, 1, L)``.
+        return_tvoc: bool, optional
+            When ``True`` also return a ``(B,)`` TVOC estimate.
+        """
+
+        # TODO: add normalisation and optional attention mechanisms.
         feat = self.backbone(x)
         logits = self.classifier(feat)
         tvoc = self.regressor(feat).squeeze(-1)

--- a/tests/test_models_shapes.py
+++ b/tests/test_models_shapes.py
@@ -7,15 +7,15 @@ from src.models.student import StudentModel
 
 
 def test_teacher_shape():
-    model = TeacherModel(num_classes=2, prior_dim=4)
+    model = TeacherModel(hidden_dim=8, prior_dim=4, num_classes=2)
     x = torch.zeros(1, 1, 10)
-    p = torch.zeros(1, 4)
-    out = model(x, p)
+    P = torch.zeros(2, 4)
+    out = model(x, P)
     assert out.shape == (1, 2)
 
 
 def test_student_shape():
-    model = StudentModel(num_classes=2)
+    model = StudentModel(num_classes=2, hidden_dim=8)
     x = torch.zeros(1, 1, 10)
     out = model(x)
     assert out.shape == (1, 2)


### PR DESCRIPTION
## Summary
- Document developer vs. user quickstarts and prior schema
- Provide bilinear teacher model and improved backbones with TODO annotations
- Add Makefile, GitHub Actions CI, and simplified configs and scripts

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b159c67d088320a0933e3faa17bff7